### PR TITLE
Issue #54: Stop listening for payment on cancel

### DIFF
--- a/js/abstracts/base-view.js
+++ b/js/abstracts/base-view.js
@@ -1,0 +1,95 @@
+var app = app || {};
+
+app.abstracts = app.abstracts || {};
+
+app.abstracts.BaseView = (function() {
+
+	'use strict';
+
+	return Backbone.View.extend({
+
+		_rendered: false,
+
+		constructor: function(options) {
+
+			this.options = options || {};
+
+			_.bindAll(this, 'render', 'close');
+
+			Backbone.View.prototype.constructor.apply(this, arguments);
+		},
+
+		isRendered: function() {
+
+			return this._rendered === true;
+		},
+
+		render: function() {
+
+			var template = this.getTemplate();
+
+			if (!template) {
+				throw new Error('Cannot render view without a template');
+			}
+
+			var data = this.serializeData();
+			var html = template(data);
+			this.$el.html(html);
+			this._rendered = true;
+			this.onRender();
+			return this;
+		},
+
+		onRender: function() {
+			// Left empty intentionally.
+			// Override as needed.
+			return this;
+		},
+
+		serializeData: function() {
+
+			return this.model && this.model.toJSON() || null;
+		},
+
+		getTemplate: function() {
+
+			var id = _.result(this, 'template');
+
+			if (!id) {
+				throw new Error('Template not specified');
+			}
+
+			var $template = id && $(id);
+
+			if (!$template || !($template.length > 0)) {
+				throw new Error('Missing template: "' + id + '"');
+			}
+
+			var html = $template && $template.html() || '';
+			return Handlebars.compile(html);
+		},
+
+		close: function() {
+
+			this.onClose();
+
+			// Stop listening to other objects (models, collections, etc).
+			this.stopListening();
+
+			// Remove all callbacks bound to the view itself.
+			this.unbind();
+
+			// Remove the view from the DOM.
+			this.remove();
+
+			return this;
+		},
+
+		onClose: function() {
+			// Left empty intentionally.
+			// Override as needed.
+			return this;
+		}
+	});
+
+})();

--- a/js/config.js
+++ b/js/config.js
@@ -9,6 +9,18 @@ app.config = (function() {
 			cellSize: 5,
 			margin: 0
 		},
+		displayPaymentAddress: {
+			listener: {
+				// When to stop performing checks (milliseconds):
+				timeout: 180000,
+				delays: {
+					// Wait time before the first check (milliseconds):
+					first: 10000,
+					// Wait time between checks (milliseconds):
+					between: 5000
+				}
+			}
+		},
 		settings: [
 			{
 				name: 'displayCurrency',

--- a/js/views/choose-payment-method.js
+++ b/js/views/choose-payment-method.js
@@ -6,7 +6,7 @@ app.views.ChoosePaymentMethod = (function() {
 
 	'use strict';
 
-	return Backbone.View.extend({
+	return app.abstracts.BaseView.extend({
 
 		className: 'choose-payment-method',
 
@@ -17,22 +17,18 @@ app.views.ChoosePaymentMethod = (function() {
 			'click .cancel': 'cancel'
 		},
 
-		initialize: function(options) {
+		serializeData: function() {
 
-			this.options = options || {};
-		},
-
-		render: function() {
-
-			var html = $(this.template).html();
-			var template = Handlebars.compile(html);
 			var data = {};
 			data.paymentMethods = _.map(app.settings.get('acceptCryptoCurrencies'), function(key) {
 				return { key: key };
 			});
-			this.$el.html(template(data));
+			return data;
+		},
+
+		onRender: function() {
+
 			this.$error = this.$('.error');
-			return this;
 		},
 
 		cancel: function() {

--- a/js/views/main.js
+++ b/js/views/main.js
@@ -6,7 +6,7 @@ app.views.Main = (function() {
 
 	'use strict';
 
-	return Backbone.View.extend({
+	return app.abstracts.BaseView.extend({
 
 		el: '#app',
 		template: '#template-main',
@@ -24,15 +24,6 @@ app.views.Main = (function() {
 			$(document).on('click', this.onDocumentClick);
 		},
 
-		render: function() {
-
-			var html = $(this.template).html();
-			var template = Handlebars.compile(html);
-			this.$el.html(template());
-			this.onRender();
-			return this;
-		},
-
 		renderView: function(name, options) {
 
 			var view = new app.views[name](options || {});
@@ -43,7 +34,7 @@ app.views.Main = (function() {
 
 			if (this.currentView) {
 
-				this.currentView.remove();
+				this.currentView.close();
 
 				if (this.currentView.className) {
 					$('body').removeClass('view-' + this.currentView.className);
@@ -106,8 +97,12 @@ app.views.Main = (function() {
 
 		changeDisplayCurrency: function(evt) {
 
-			console.log('changeDisplayCurrency');
 			app.settings.set('displayCurrency', $(evt.target).val()).save();
+		},
+
+		onClose: function() {
+
+			$(document).off('click', this.onDocumentClick);
 		}
 
 	});

--- a/js/views/pay.js
+++ b/js/views/pay.js
@@ -6,7 +6,7 @@ app.views.Pay = (function() {
 
 	'use strict';
 
-	return Backbone.View.extend({
+	return app.abstracts.BaseView.extend({
 
 		className: 'pay',
 
@@ -19,11 +19,9 @@ app.views.Pay = (function() {
 
 		amount: '0',
 
-		render: function() {
+		serializeData: function() {
 
-			var html = $(this.template).html();
-			var template = Handlebars.compile(html);
-			var data = {
+			return {
 				amount: {
 					display: {
 						value: this.amount,
@@ -31,12 +29,13 @@ app.views.Pay = (function() {
 					}
 				}
 			};
+		},
 
-			this.$el.html(template(data));
+		onRender: function() {
+
 			this.$amount = this.$('.amount-value');
 			this.$error = this.$('.error');
 			this.updateAmount();
-			return this;
 		},
 
 		onNumberPadKeyPressed: function(evt) {

--- a/js/views/payment-confirmation.js
+++ b/js/views/payment-confirmation.js
@@ -6,7 +6,7 @@ app.views.PaymentConfirmation = (function() {
 
 	'use strict';
 
-	return Backbone.View.extend({
+	return app.abstracts.BaseView.extend({
 
 		className: 'payment-confirmation',
 
@@ -16,24 +16,11 @@ app.views.PaymentConfirmation = (function() {
 			'click .done': 'done'
 		},
 
-		initialize: function(options) {
-
-			this.options = options || {};
-		},
-
-		render: function() {
-
-			var html = $(this.template).html();
-			var template = Handlebars.compile(html);
-			this.$el.html(template());
-			return this;
-		},
-
 		done: function() {
 
 			// Navigate back to the homescreen
 			app.router.navigate('main', { trigger: true });
-		},
+		}
 
 	});
 

--- a/js/views/payment-details.js
+++ b/js/views/payment-details.js
@@ -1,5 +1,3 @@
-// PaymentDetail
-
 var app = app || {};
 
 app.views = app.views || {};
@@ -8,30 +6,20 @@ app.views.PaymentDetails = (function() {
 
 	'use strict';
 
-	return Backbone.View.extend({
+	return app.abstracts.BaseView.extend({
 
 		className: 'payment-detail',
 		template: '#template-payment-details',
 
-		events: {
-		},
+		serializeData: function() {
 
-        initialize: function(options) {
-
-			this.options = options || {};
-		},
-
-		render: function() {
-			
 			if (!app.paymentRequests.get(this.options.paymentId)) {
 				app.paymentRequests.fetch();
 			}
-			var paymentInfo = app.paymentRequests.get(this.options.paymentId).attributes;
 
-			var html = $(this.template).html();
-			var template = Handlebars.compile(html);
-			this.$el.html(template(paymentInfo));
-			return this;
-		},
+			return app.paymentRequests.get(this.options.paymentId).attributes;
+		}
+
 	});
+
 })();

--- a/js/views/payment-history.js
+++ b/js/views/payment-history.js
@@ -1,5 +1,3 @@
-// PaymentHistory
-
 var app = app || {};
 
 app.views = app.views || {};
@@ -8,7 +6,7 @@ app.views.PaymentHistory = (function() {
 
 	'use strict';
 
-	return Backbone.View.extend({
+	return app.abstracts.BaseView.extend({
 
 		className: 'payment-history',
 		template: '#template-payment-history',
@@ -17,7 +15,8 @@ app.views.PaymentHistory = (function() {
 			'click .payment-history-item': 'gotoPaymentDetails'
 		},
 
-		render: function() {
+		serializeData: function() {
+
 			var data = {};
 
 			app.paymentRequests.fetch({
@@ -29,17 +28,14 @@ app.views.PaymentHistory = (function() {
 				error: function() {
 					throw new Error('Fail to get Payments!');
 				}
-			})
+			});
 
-			var html = $(this.template).html();
-			var template = Handlebars.compile(html);
-			this.$el.html(template(data));
-			return this;
+			return data;
 		},
 
-		gotoPaymentDetails: function(ev) {
+		gotoPaymentDetails: function(evt) {
 
-			var paymentId = $(ev.currentTarget).attr('data-payment-id');
+			var paymentId = $(evt.currentTarget).attr('data-payment-id');
 			app.router.navigate('payment-details/' + paymentId, { trigger: true });
 		}
 	});

--- a/js/views/settings.js
+++ b/js/views/settings.js
@@ -6,7 +6,7 @@ app.views.Settings = (function() {
 
 	'use strict';
 
-	return Backbone.View.extend({
+	return app.abstracts.BaseView.extend({
 
 		className: 'settings',
 		template: '#template-settings',
@@ -21,9 +21,8 @@ app.views.Settings = (function() {
 			_.bindAll(this, 'clearSuccess');
 		},
 
-		render: function() {
-			var html = $(this.template).html();
-			var template = Handlebars.compile(html);
+		serializeData: function() {
+
 			var data = {};
 			var acceptCryptoCurrencies = app.settings.get('acceptCryptoCurrencies');
 			data.paymentMethods = _.map(_.keys(app.paymentMethods), function(key) {
@@ -68,9 +67,7 @@ app.views.Settings = (function() {
 				return setting;
 			});
 
-			this.$el.html(template(data));
-			this.onRender();
-			return this;
+			return data;
 		},
 
 		onRender: function() {


### PR DESCRIPTION
* Introduced a [base view class](https://github.com/Learn-by-doing/crypto-terminal/pull/61/files#diff-834928a60376c2e967a9cceb8d2f5638) that all views now inherit from. This reduces code duplication and makes the views cleaner.
* Each view now has two new methods:
  * `close` - removes the view's HTML from the DOM, cleans up event listeners, and calls `onClose`
  * `onClose` - does nothing by default; should be overriden with custom code to be executed whenever the view is closed.