### PR TITLE
Fixing payment amount overflow

### DIFF
--- a/css/amount.css
+++ b/css/amount.css
@@ -17,6 +17,8 @@
 	text-align: right;
 	box-sizing: border-box;
 	padding-right: .5rem;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 .amount-currency {
 	float: left;

--- a/js/views/pay.js
+++ b/js/views/pay.js
@@ -135,7 +135,11 @@ app.views.Pay = (function() {
 				// Don't add if there is no value:
 				!value ||
 				// In the case of a dot, only add if there isn't already a dot:
-				(value === '.' && this.amount.indexOf('.') !== -1)
+				(value === '.' && this.amount.indexOf('.') !== -1) ||
+				// to keep this.amount var without leading zeroes.
+				(value == 0 && this.amount == 0) ||
+				// max length of amount so it does not overflow the UI.
+				(this.amount.length > 11)
 			) {
 				return;
 			}


### PR DESCRIPTION
fixing a limit of 11 characters and also hiding overflow with a ellipsis ```...``` in case in a specific device the amount is too long.